### PR TITLE
Coverall fix

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,8 +2,8 @@
 source = 
     .
 omit =
-    enginetest
-    */tests*
+    ./enginetest
+    */tests
 
 [report]
 exclude_lines =

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,8 +1,8 @@
 [run]
-include = 
-    engine.py
-    instrument/*
+source = 
+    .
 omit =
+    enginetest
     */tests*
 
 [report]

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,7 +1,7 @@
 [run]
 include = 
     engine.py
-    instruments/*
+    instrument/*
 omit =
     */tests*
 

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,8 @@
 [run]
+include = .
 omit =
-    */*test*
+    */tests*
+    enginetest
 
 [report]
 exclude_lines =

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,5 @@
 [run]
-include = .
+include = *
 omit =
     */tests*
     enginetest

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,8 +1,9 @@
 [run]
-include = *
+include = 
+    engine.py
+    instruments/*
 omit =
     */tests*
-    enginetest
 
 [report]
 exclude_lines =

--- a/.coveragerc
+++ b/.coveragerc
@@ -2,8 +2,8 @@
 source = 
     .
 omit =
-    ./enginetest
-    */tests
+    ./enginetest/*
+    */tests/*
 
 [report]
 exclude_lines =


### PR DESCRIPTION
Coverage report was including a lot of extraneous files from Python built-in and pyvisa libraries, so the numbers weren't exactly correct.  Fixed now.
